### PR TITLE
Print clickable url with port

### DIFF
--- a/garcon.c
+++ b/garcon.c
@@ -25,7 +25,7 @@ enum {
   time_buffer_size = 100
 };
 
-const static char default_filename[] = "index.html";
+static const char default_filename[] = "index.html";
 
 struct parser_data {
   buffer_t *url;

--- a/garcon.c
+++ b/garcon.c
@@ -344,7 +344,7 @@ int main(int argc, char **argv)
   command_option(&cmd, "-p", "--port [arg]", "Which port to listen on (default 8888)", set_port);
   command_parse(&cmd, argc, argv);
 
-  printf("Garçon! Serving content from %s on port %ld\n", options.root, options.port);
+  printf("Garçon! Serving content from %s on http://localhost:%ld/\n", options.root, options.port);
 
   const int socket = open_connection(options.port);
 


### PR DESCRIPTION
This patch makes the printed port information clickable (where available). Making things a tiny bit more convenient.